### PR TITLE
Add audio support for Opus and USB mic

### DIFF
--- a/meta-secluso-os/pi-debug-image.yml
+++ b/meta-secluso-os/pi-debug-image.yml
@@ -21,7 +21,7 @@ signers:
     gpg_keyserver: keyserver.ubuntu.com
 
 # The machine as it is written into the `local.conf` of bitbake.
-machine: raspberrypi4-64
+machine: raspberrypi0-2w-64
 # The distro name as it is written into the `local.conf` of bitbake.
 # Selects conf/distro/secluso.conf from meta-secluso-os.
 distro: secluso
@@ -166,6 +166,9 @@ local_conf_header:
     # Not all kernel-modules need to be included for proper operation.
     # TODO: Remove unnecesary kernel modules
     IMAGE_INSTALL:append = " kmod i2c-tools kernel-modules"
+    
+    # Microphone-related.
+    IMAGE_INSTALL:append = " alsa-utils alsa-state opus-tools"
 
     # Referenced from https://hub.mender.io/t/how-to-configure-networking-using-systemd-in-yocto-project/1097
     # This installs the necessary firmware to connect to WiFi. See LICENSE_FLAGS_ACCEPTED for a relevant discussion.

--- a/meta-secluso-os/pi-debug-image.yml
+++ b/meta-secluso-os/pi-debug-image.yml
@@ -21,7 +21,7 @@ signers:
     gpg_keyserver: keyserver.ubuntu.com
 
 # The machine as it is written into the `local.conf` of bitbake.
-machine: raspberrypi0-2w-64
+machine: raspberrypi4-64
 # The distro name as it is written into the `local.conf` of bitbake.
 # Selects conf/distro/secluso.conf from meta-secluso-os.
 distro: secluso
@@ -118,7 +118,7 @@ local_conf_header:
     # meta-raspberrypi sets WKS_FILE with a weak assignment (?=), so we don't need a force override
     # wks is a custom configuration script used by the wic tool to define the partitioning layout
     # override theirs with our modified version
-    WKS_FILE:raspberrypi0-2w-64 = "sdcard-raspberrypi.wks"
+    WKS_FILE = "sdcard-raspberrypi.wks"
     
     # Reference: https://wiki.yoctoproject.org/wiki/Reproducible_Builds
     # These should be default values. We re-affirm them here to be safe.
@@ -159,8 +159,8 @@ local_conf_header:
     ENABLE_CAMERA = "0"
     ENABLE_I2C = "1"
     # Ensure the ov5647 & imx219 overlays are built and deployed to /boot/overlays/
-    KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/ov5647.dtbo"
-    KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/imx219.dtbo"
+    KERNEL_DEVICETREE:append = " overlays/ov5647.dtbo"
+    KERNEL_DEVICETREE:append = " overlays/imx219.dtbo"
 
     # Ensure the kernel modules are installed into the image. Needed to properly load in the camera into libcamera
     # Not all kernel-modules need to be included for proper operation.

--- a/meta-secluso-os/pi-official-image.yml
+++ b/meta-secluso-os/pi-official-image.yml
@@ -158,6 +158,9 @@ local_conf_header:
     # Not all kernel-modules need to be included for proper operation.
     # TODO: Remove unnecesary kernel modules
     IMAGE_INSTALL:append = " kmod i2c-tools kernel-modules"
+    
+    # Microphone-related.
+    IMAGE_INSTALL:append = " alsa-utils alsa-state opus-tools"
 
     # Referenced from https://hub.mender.io/t/how-to-configure-networking-using-systemd-in-yocto-project/1097
     # This installs the necessary firmware to connect to WiFi. See LICENSE_FLAGS_ACCEPTED for a relevant discussion.

--- a/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub-crates.inc
+++ b/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub-crates.inc
@@ -167,6 +167,8 @@ SRC_URI += " \
     crate://crates.io/ocb3/0.1.0 \
     crate://crates.io/once_cell/1.21.4 \
     crate://crates.io/opaque-debug/0.3.1 \
+    crate://crates.io/opusic-c/1.6.1 \
+    crate://crates.io/opusic-sys/0.7.3 \
     crate://crates.io/openssl-probe/0.2.1 \
     crate://crates.io/p256/0.13.2 \
     crate://crates.io/p384/0.13.1 \
@@ -534,6 +536,8 @@ SRC_URI[num-traits-0.2.19.sha256sum] = "071dfc062690e90b734c0b2273ce72ad0ffa95f0
 SRC_URI[ocb3-0.1.0.sha256sum] = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
 SRC_URI[once_cell-1.21.4.sha256sum] = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 SRC_URI[opaque-debug-0.3.1.sha256sum] = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+SRC_URI[opusic-c-1.6.1.sha256sum] = "89f8e9c909466f15e60277212cc4fec082c68a5e1c9f6e373eee716fec2fed47"
+SRC_URI[opusic-sys-0.7.3.sha256sum] = "2804e694ef0de3b4cbb254de565053b7cb48d3398df7fd60c6c62bed40c5372a"
 SRC_URI[openssl-probe-0.2.1.sha256sum] = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 SRC_URI[p256-0.13.2.sha256sum] = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 SRC_URI[p384-0.13.1.sha256sum] = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"

--- a/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub_1.0.2.bb
+++ b/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub_1.0.2.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b769fddc23425484f6d001e49426c2ee"
 
 # This is our own repository (set to an immutable commit)
 SRC_URI = "git://github.com/secluso/core.git;nobranch=1;protocol=https"
-SRCREV = "7bcbb4e4785fddab7f309b9535b29b98d54136fc"
+SRCREV = "be2d83bb2a1731178e0a43d67a960515f20297c5"
 
 # Cargo fingerprints local path crates using their absolute source path
 # Thus, we copy the workspace to a canonical location before compiling.
@@ -37,6 +37,12 @@ CARGO_BUILD_FLAGS += "--features raspberry"
 RUSTFLAGS += " --remap-path-prefix=${WORKDIR}=/usr/src/debug/${PN}/${PV}"
 RUSTFLAGS += " --remap-path-prefix=${S}=/usr/src/debug/${PN}/${PV}/sources"
 RUSTFLAGS += " --remap-path-prefix=${CARGO_HOME}=cargo_home"
+
+# opusic-sys compiles bundled C sources via a cargo build script.
+# Rust path remaps alone are thus not enough to rewrite __FILE__ strings that would embed TMPDIR into the binary.
+CFLAGS += " -ffile-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${PV}"
+CFLAGS += " -ffile-prefix-map=${S}=/usr/src/debug/${PN}/${PV}/sources"
+CFLAGS += " -ffile-prefix-map=${CARGO_HOME}=cargo_home"
 
 # https://wiki.koansoftware.com/index.php/Add_a_systemd_service_file_into_a_Yocto_image
 SYSTEMD_AUTO_ENABLE = "enable"


### PR DESCRIPTION
Adds opusic-sys to the image along with alsa. Updated commit ref to the core PR branch that supports Opus and checks for the USB mic.

fixes #19 