### PR TITLE
Add IMX708 device tree overlay

### DIFF
--- a/meta-secluso-os/pi-debug-image.yml
+++ b/meta-secluso-os/pi-debug-image.yml
@@ -169,6 +169,7 @@ local_conf_header:
     # Ensure the ov5647 & imx219 overlays are built and deployed to /boot/overlays/
     KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/ov5647.dtbo"
     KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/imx219.dtbo"
+    KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/imx708.dtbo"
 
     # Ensure the kernel modules are installed into the image. Needed to properly load in the camera into libcamera
     # Not all kernel-modules need to be included for proper operation.

--- a/meta-secluso-os/pi-official-image.yml
+++ b/meta-secluso-os/pi-official-image.yml
@@ -161,6 +161,7 @@ local_conf_header:
     # Ensure the ov5647 & imx219 overlays are built and deployed to /boot/overlays/
     KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/ov5647.dtbo"
     KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/imx219.dtbo"
+    KERNEL_DEVICETREE:append:raspberrypi0-2w-64 = " overlays/imx708.dtbo"
 
     # Ensure the kernel modules are installed into the image. Needed to properly load in the camera into libcamera
     # Not all kernel-modules need to be included for proper operation.

--- a/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub_1.0.2.bb
+++ b/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub_1.0.2.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b769fddc23425484f6d001e49426c2ee"
 
 # This is our own repository (set to an immutable commit)
 SRC_URI = "git://github.com/secluso/core.git;nobranch=1;protocol=https"
-SRCREV = "7bcbb4e4785fddab7f309b9535b29b98d54136fc"
+SRCREV = "9638e5c5b822ecce370213673031ab6294e8668f"
 
 # Cargo fingerprints local path crates using their absolute source path
 # Thus, we copy the workspace to a canonical location before compiling.

--- a/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub_1.0.2.bb
+++ b/meta-secluso-os/recipes-secluso-camera-hub/secluso-camera-hub/secluso-camera-hub_1.0.2.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b769fddc23425484f6d001e49426c2ee"
 
 # This is our own repository (set to an immutable commit)
 SRC_URI = "git://github.com/secluso/core.git;nobranch=1;protocol=https"
-SRCREV = "9638e5c5b822ecce370213673031ab6294e8668f"
+SRCREV = "09ee868c815f89e2de3a1c7ab138912b0a372afd"
 
 # Cargo fingerprints local path crates using their absolute source path
 # Thus, we copy the workspace to a canonical location before compiling.


### PR DESCRIPTION
Adds IMX708 device tree overlay. Updates camera_hub commit reference to the one that supports IMX708 (auto-detects and sets appropriate resolution).

Pairs with https://github.com/secluso/core/pull/116
Fixes https://github.com/secluso/core/issues/130